### PR TITLE
fix: set userprofile info on localstorage

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,20 +17,15 @@ import Messages from "./pages/Messages/messages";
 import ProfileEdit from "./pages/ProfilePage/ProfileEdit/profileEdit";
 import UserFollowerFollowing from "./pages/UserFollowerFollowing/userFollowerFollowing";
 
-import { getProfileDetails } from "./actions/profile";
-
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import NotFound from "./components/NotFound/notFound";
 
 const App = () => {
-  const dispatch = useDispatch();
   let user = JSON.parse(localStorage.getItem("profile"));
 
   const [isAuth, setIsAuth] = useState("");
-  useEffect(() => {
-    user && dispatch(getProfileDetails(user?.id, true));
-  }, []);
+
   useEffect(() => {
     window.location.pathname === "/auth" ? setIsAuth(true) : setIsAuth(false);
   }, [window.location.pathname, user]);

--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -2,6 +2,7 @@ import * as api from "../api";
 import { AUTH } from "../constants/actionTypes";
 import Cookies from "js-cookie";
 import { toast } from "react-toastify";
+import { getProfileDetails } from "./profile";
 
 // action creators
 export const signUp = (formData, history) => async (dispatch) => {
@@ -16,6 +17,7 @@ export const signUp = (formData, history) => async (dispatch) => {
     });
     // step : 4 disptach action type and data to reducers and it retuns something
     dispatch({ type: AUTH, data });
+    dispatch(getProfileDetails(data.data.id, true));
     history.push("/");
   } catch (error) {
     const message =
@@ -37,6 +39,7 @@ export const logIn = (formData, history) => async (dispatch) => {
       secure: true,
     });
     dispatch({ type: AUTH, data });
+    dispatch(getProfileDetails(data.data.id, true));
     history.push("/");
   } catch (error) {
     const message =

--- a/client/src/actions/profile.js
+++ b/client/src/actions/profile.js
@@ -90,6 +90,9 @@ export const getProfileDetails = (id, isUser) => async (dispatch) => {
       dispatch({ type: START_USER_PROFILE_LOADING });
 
       const { data } = await api.fetchProfileDetails(id, accessTokenFromCookie);
+
+      localStorage.setItem("userProfileDetails", JSON.stringify(data.data));
+
       dispatch({ type: GET_USER_PROFILE_DETAILS, payload: data });
 
       dispatch({ type: END_USER_PROFILE_LOADING });

--- a/client/src/components/NavBar/navBar.js
+++ b/client/src/components/NavBar/navBar.js
@@ -16,7 +16,8 @@ import { getPostByUser } from "../../actions/posts";
 const NavBar = () => {
   const [user, setUser] = useState(JSON.parse(localStorage.getItem("profile")));
 
-  const { userProfileDetails } = useSelector((state) => state.profile);
+  const [userProfileDetails, setUserProfileDetails] = useState({});
+  
   const dispatch = useDispatch();
   const location = useLocation();
   const history = useHistory();
@@ -28,8 +29,11 @@ const NavBar = () => {
       // if (decodedToken.exp * 1000 < new Date().getTime()) logout();
     }
     setUser(JSON.parse(localStorage.getItem("profile")));
+    setUserProfileDetails(
+      JSON.parse(localStorage.getItem("userProfileDetails"))
+    );
     // TODO: Need to check why we are setting user on location change
-  }, [location]);
+  }, [location, user]);
 
   const isChatPage = useLocation().pathname === "/chats";
 

--- a/client/src/pages/Home/home.js
+++ b/client/src/pages/Home/home.js
@@ -18,8 +18,9 @@ const Home = () => {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const { userProfileDetails, isUserProfileLoading } = useSelector(
-    (state) => state.profile
+  const { isUserProfileLoading } = useSelector((state) => state.profile);
+  const userProfileDetails = JSON.parse(
+    localStorage.getItem("userProfileDetails")
   );
   const { posts, isPostLoading } = useSelector((state) => state.posts);
 
@@ -28,7 +29,6 @@ const Home = () => {
   }
 
   useEffect(() => {
-    user && dispatch(getProfileDetails(id, true));
     user && dispatch(getPostsByFollowing());
   }, []);
 

--- a/client/src/pages/UserFollowerFollowing/userFollowerFollowing.js
+++ b/client/src/pages/UserFollowerFollowing/userFollowerFollowing.js
@@ -37,7 +37,7 @@ const UserFollowerFollowing = () => {
   } = useSelector((state) => state.profile);
 
   useEffect(() => {
-    if (!profileId) {
+    if (profileId) {
       dispatch(getFollowingProfileDetails(profileId));
       dispatch(getFollowersProfileDetails(profileId));
     }

--- a/client/src/reducers/profile.js
+++ b/client/src/reducers/profile.js
@@ -20,7 +20,7 @@ import {
 const initState = {
   count: {},
   profileDetails: {},
-  userProfileDetails:{},
+  userProfileDetails: {},
   followingProfile: [],
   followersProfile: [],
   isProfileLoading: true,
@@ -62,6 +62,7 @@ export default (state = initState, action) => {
         followersProfile: action.payload.data,
       };
     case GET_USER_PROFILE_DETAILS:
+      console.log(action.payload.data);
       return {
         ...state,
         userProfileDetails: action.payload.data,


### PR DESCRIPTION
Set userprofile detrails on localstorage and used it, due to api call is sent on every refresh for user profile details call, since the static data used on Navbar.